### PR TITLE
Improve path validation

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node test/modulePath.test.js"
   },
   "dependencies": {
     "express": "^4.18.2"

--- a/server/test/modulePath.test.js
+++ b/server/test/modulePath.test.js
@@ -1,0 +1,8 @@
+import assert from 'assert';
+import { validateModuleName } from '../validate.js';
+
+assert.strictEqual(validateModuleName('foo/bar.jslt'), true);
+assert.strictEqual(validateModuleName('../evil.jslt'), false);
+assert.strictEqual(validateModuleName('/abs/path.jslt'), false);
+
+console.log('Test passed');

--- a/server/validate.js
+++ b/server/validate.js
@@ -1,0 +1,6 @@
+import path from 'path';
+
+export function validateModuleName(name) {
+  const normalized = path.normalize(name);
+  return !path.isAbsolute(name) && !normalized.split(path.sep).includes('..');
+}


### PR DESCRIPTION
## Summary
- validate JSLT module paths and reject absolute or traversing paths
- expose a `validateModuleName` helper
- add tests for malicious module paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740b72f8388322be556947cc48d2b3